### PR TITLE
Replace for-each-in loop with for-of

### DIFF
--- a/lib/main.js
+++ b/lib/main.js
@@ -14,7 +14,7 @@ function onWindowOpen(window) {
   });
 }
 
-for each (var window in windows)
+for (let window of windows)
   onWindowOpen(window);
 
 windows.on('open', onWindowOpen);


### PR DESCRIPTION
SpiderMonkey's non-standard for-each-in loops have been removed in the Firefox Nightly channel (only) by [bug 1293305](https://bugzilla.mozilla.org/show_bug.cgi?id=1293305).

```
  Message: SyntaxError: missing ( after for
  Stack:
    @resource://jid0-szimol45ib8oddgoubg0buqmjec-at-jetpack/lib/main.js:17:undefined
run@resource://gre/modules/commonjs/sdk/addon/runner.js:147:19
startup/</<@resource://gre/modules/commonjs/sdk/addon/runner.js:87:9
Handler.prototype.process@resource://gre/modules/Promise-backend.js:932:23
this.PromiseWalker.walkerLoop@resource://gre/modules/Promise-backend.js:813:7
Promise*this.PromiseWalker.scheduleWalkerLoop@resource://gre/modules/Promise-backend.js:744:11
this.PromiseWalker.schedulePromise@resource://gre/modules/Promise-backend.js:776:7
this.PromiseWalker.completePromise@resource://gre/modules/Promise-backend.js:711:7
handler@resource://gre/modules/commonjs/sdk/addon/window.js:56:3
EventListener.handleEvent*EventTargetInterposition.methods.addEventListener@resource://gre/modules/RemoteAddonsParent.jsm:644:5
AddonInterpositionService.prototype.interposeProperty/desc.value@jar:file:///Applications/Nightly.app/Contents/Resources/omni.ja!/components/multiprocessShims.js:159:52
@resource://gre/modules/commonjs/sdk/addon/window.js:54:1
startup/<@resource://gre/modules/commonjs/sdk/addon/runner.js:72:21
Handler.prototype.process@resource://gre/modules/Promise-backend.js:932:23
this.PromiseWalker.walkerLoop@resource://gre/modules/Promise-backend.js:813:7
Promise*this.PromiseWalker.scheduleWalkerLoop@resource://gre/modules/Promise-backend.js:744:11
this.PromiseWalker.schedulePromise@resource://gre/modules/Promise-backend.js:776:7
this.PromiseWalker.completePromise@resource://gre/modules/Promise-backend.js:711:7
listener/<@resource://gre/modules/sdk/system/Startup.js:52:46
```