### PR TITLE
Fix inconsistent tab placement on Chrome after service worker idles

### DIFF
--- a/manifest-chrome.json
+++ b/manifest-chrome.json
@@ -7,6 +7,7 @@
     "service_worker": "service_worker.js"
   },
   "permissions": [
+     "storage"
   ],
   "manifest_version": 3,
   "homepage_url": "https://github.com/autonome/always-right",

--- a/service_worker.js
+++ b/service_worker.js
@@ -123,9 +123,10 @@ const makeRight = async newTab => {
   }
 
   // Refetch — tab references go STALE. Dammit.
-  const [activeTab, freshNewTab] = await Promise.all([
+  const [activeTab, freshNewTab, win] = await Promise.all([
     safeGetTab(activeTabCache.id),
     safeGetTab(newTab.id),
+    api.windows.get(newTab.windowId, { populate: true }),
   ]);
   if (!activeTab || !freshNewTab) return;
 
@@ -139,13 +140,19 @@ const makeRight = async newTab => {
   // onUpdated milliseconds later — if the tab is now in a group, leave it.
   if (isInGroup(freshNewTab)) return;
 
+  // Skip tabs Chrome placed somewhere specific. A fresh user-initiated tab
+  // (Ctrl+T, click "+") always lands at the end of the strip; anything else
+  // (Ctrl+Shift+T or "Reopen closed tab" restoring to original position,
+  // middle-click placed adjacent to opener) represents intentional placement
+  // that we shouldn't override.
+  if (freshNewTab.index !== win.tabs.length - 1) return;
+
   // To the right
   let targetIndex = activeTab.index + 1;
 
   // If the active tab is pinned, we have to set the target index
   // to that of the first non-pinned tab.
   if (activeTab.pinned) {
-    const win = await api.windows.get(newTab.windowId, { populate: true });
     targetIndex = getFirstNonPinnedTab(win).index;
   }
 

--- a/service_worker.js
+++ b/service_worker.js
@@ -6,11 +6,7 @@ const api = isChrome ? chrome : browser;
 // https://issues.chromium.org/issues/40805401
 if (isChrome) {
   // https://stackoverflow.com/questions/66618136/persistent-service-worker-in-chrome-extension
-  const keepAlive = () => {
-    setInterval(api.runtime.getPlatformInfo, 20000);
-  };
-  api.runtime.onStartup.addListener(keepAlive);
-  keepAlive();
+  setInterval(api.runtime.getPlatformInfo, 20000);
 }
 
 // new firefoxen have a setting for this
@@ -28,17 +24,95 @@ const tryBrowserPref = async () =>{
   return true;
 };
 
-// Cache the active tab. Populated via onActivated and rehydrated on demand
-// in makeRight() after the service worker restarts — onActivated only fires
-// on tab switches, not on SW wake.
-let activeTabCache = null;
-api.tabs.onActivated.addListener(async (activeInfo) => {
-  activeTabCache = await api.tabs.get(activeInfo.tabId);
+// "User has activated a tab since the last browser cold start" flag.
+// Used to gate makeRight() during session restore — Chrome auto-activates
+// the active restored tab during session restore, so we can't trust a bare
+// onActivated as a "user has interacted" signal. Stored in storage.session
+// so the gate survives MV3 service-worker termination but is cleared on
+// browser restart (or when the last window closes, for the case where
+// Chrome's background process keeps the session alive).
+const ACTIVATED_KEY = 'userHasActivated';
+const clearGate = async () => {
+  try { await api.storage.session.remove(ACTIVATED_KEY); } catch (e) {}
+};
+api.runtime.onStartup.addListener(clearGate);
+api.windows.onRemoved.addListener(async () => {
+  try {
+    const wins = await api.windows.getAll();
+    if (wins.length === 0) await clearGate();
+  } catch (e) {}
 });
+
+const isInGroup = tab => tab.groupId !== undefined && tab.groupId !== -1;
+const safeGetTab = id => api.tabs.get(id).catch(() => null);
+
+// Track recent onCreated events so we can distinguish a session-restore
+// burst (many creations in quick succession) from a single user-initiated
+// new tab (Ctrl+T, middle-click, etc).
+let recentCreations = [];
+const isInCreationBurst = () => {
+  const now = Date.now();
+  recentCreations = recentCreations.filter(ts => now - ts < 1000);
+  return recentCreations.length >= 3;
+};
+
+// Inter-event quiescence threshold: if no new onCreated event arrives within
+// this window, the event stream has settled and we can decide whether the
+// preceding activity was a session-restore burst or a single user action.
+// This is a small upper bound on the gap between consecutive Chrome-
+// dispatched onCreated events during a burst — nothing depends on the
+// burst's *total* duration, only on inter-event gaps.
+const QUIESCENCE_MS = 50;
+
+// A pending decision triggered by an onActivated, waiting for event
+// quiescence before opening the gate. onCreated handlers reset its timer
+// so the wait extends across an entire burst, however long.
+let pendingActivation = null;
+
+const scheduleActivationDecision = (activeInfo) => {
+  if (pendingActivation) clearTimeout(pendingActivation.timerId);
+  const timerId = setTimeout(async () => {
+    pendingActivation = null;
+    if (isInCreationBurst()) return;
+    try {
+      await api.storage.session.set({ [ACTIVATED_KEY]: true });
+      activeTabCache = await api.tabs.get(activeInfo.tabId);
+    } catch (e) { /* tab closed mid-activation */ }
+  }, QUIESCENCE_MS);
+  pendingActivation = { activeInfo, timerId };
+};
+
+// Cache the active tab. Populated via the activation decision above and
+// rehydrated on demand in makeRight() after the service worker restarts.
+let activeTabCache = null;
+api.tabs.onActivated.addListener(scheduleActivationDecision);
 
 // Move the referenced tab to the immediate right of the active tab,
 // or to the immediate right of the last pinned tab.
 const makeRight = async newTab => {
+  recentCreations.push(Date.now());
+  // Bound the array — isInCreationBurst() filters lazily, so under sustained
+  // tab creation without intervening onActivated events it could grow.
+  if (recentCreations.length > 50) {
+    const cutoff = Date.now() - 1000;
+    recentCreations = recentCreations.filter(ts => ts >= cutoff);
+  }
+
+  // Extend any pending activation decision: a new onCreated means the event
+  // stream isn't quiet yet, so the gate decision should keep waiting.
+  if (pendingActivation) {
+    scheduleActivationDecision(pendingActivation.activeInfo);
+  }
+
+  // Never yank a tab out of a tab group. Catches Chrome placing a new tab
+  // inside an existing group (Ctrl+T while focused on a grouped tab).
+  if (isInGroup(newTab)) return;
+
+  // Don't run during session restore: the gate stays closed until the user
+  // has actually activated a tab post-restore.
+  const { [ACTIVATED_KEY]: ready } = await api.storage.session.get(ACTIVATED_KEY);
+  if (!ready) return;
+
   // No active tab cached — service worker was just woken up by this event.
   // Repopulate from the current window so we don't drop the first tab opened
   // after an SW restart.
@@ -49,33 +123,31 @@ const makeRight = async newTab => {
   }
 
   // Refetch — tab references go STALE. Dammit.
-  let activeTab;
-  try {
-    activeTab = await api.tabs.get(activeTabCache.id);
-  } catch (e) { return; }
+  const [activeTab, freshNewTab] = await Promise.all([
+    safeGetTab(activeTabCache.id),
+    safeGetTab(newTab.id),
+  ]);
+  if (!activeTab || !freshNewTab) return;
 
   // The new tab either dragged to new window or something went wrong.
   if (newTab.windowId != activeTab.windowId) {
     return;
   }
 
+  // Re-check groupId against the fresh fetch. During session restore, grouped
+  // tabs come in with groupId=-1 at onCreated and get assigned a group via
+  // onUpdated milliseconds later — if the tab is now in a group, leave it.
+  if (isInGroup(freshNewTab)) return;
+
   // To the right
   let targetIndex = activeTab.index + 1;
-
-  // We need current window for a few things required for correct tab placement.
-  const win = await api.windows.get(newTab.windowId, { populate: true });
 
   // If the active tab is pinned, we have to set the target index
   // to that of the first non-pinned tab.
   if (activeTab.pinned) {
+    const win = await api.windows.get(newTab.windowId, { populate: true });
     targetIndex = getFirstNonPinnedTab(win).index;
   }
-
-  // Refetch — the event-payload index is stale by now.
-  let freshNewTab;
-  try {
-    freshNewTab = await api.tabs.get(newTab.id);
-  } catch (e) { return; }
 
   // Only bother moving if it wouldn't organically be placed immediately to the
   // right of the active tab.

--- a/service_worker.js
+++ b/service_worker.js
@@ -28,9 +28,9 @@ const tryBrowserPref = async () =>{
   return true;
 };
 
-// Cache the active tab. Populated only via onActivated, so it stays null
-// until Chrome activates a tab — which naturally gates makeRight() during
-// session restore (onCreated fires before onActivated).
+// Cache the active tab. Populated via onActivated and rehydrated on demand
+// in makeRight() after the service worker restarts — onActivated only fires
+// on tab switches, not on SW wake.
 let activeTabCache = null;
 api.tabs.onActivated.addListener(async (activeInfo) => {
   activeTabCache = await api.tabs.get(activeInfo.tabId);
@@ -39,10 +39,20 @@ api.tabs.onActivated.addListener(async (activeInfo) => {
 // Move the referenced tab to the immediate right of the active tab,
 // or to the immediate right of the last pinned tab.
 const makeRight = async newTab => {
-  // No active tab yet — still in session restore or pre-interaction.
-  if (!activeTabCache) return;
+  // No active tab cached — service worker was just woken up by this event.
+  // Repopulate from the current window so we don't drop the first tab opened
+  // after an SW restart.
+  if (!activeTabCache) {
+    const [t] = await api.tabs.query({ active: true, windowId: newTab.windowId });
+    if (!t) return;
+    activeTabCache = t;
+  }
 
-  const activeTab = activeTabCache;
+  // Refetch — tab references go STALE. Dammit.
+  let activeTab;
+  try {
+    activeTab = await api.tabs.get(activeTabCache.id);
+  } catch (e) { return; }
 
   // The new tab either dragged to new window or something went wrong.
   if (newTab.windowId != activeTab.windowId) {
@@ -52,25 +62,25 @@ const makeRight = async newTab => {
   // To the right
   let targetIndex = activeTab.index + 1;
 
-  // Only bother moving if it wouldn't organically be placed immediately to the
-  // right of the active tab.
-  if (newTab.index == targetIndex) {
-    return;
-  }
-
   // We need current window for a few things required for correct tab placement.
-  // And apparently tab references go STALE. Dammit.
-  const win = await api.windows.getCurrent({ populate: true });
-
-  // Maybe is a restored tab, or another add-on, or something else is wonky.
-  if (newTab.index < win.tabs.length - 1 || newTab.index > win.tabs.length - 1) {
-    return;
-  }
+  const win = await api.windows.get(newTab.windowId, { populate: true });
 
   // If the active tab is pinned, we have to set the target index
   // to that of the first non-pinned tab.
   if (activeTab.pinned) {
     targetIndex = getFirstNonPinnedTab(win).index;
+  }
+
+  // Refetch — the event-payload index is stale by now.
+  let freshNewTab;
+  try {
+    freshNewTab = await api.tabs.get(newTab.id);
+  } catch (e) { return; }
+
+  // Only bother moving if it wouldn't organically be placed immediately to the
+  // right of the active tab.
+  if (freshNewTab.index == targetIndex) {
+    return;
   }
 
   // YOU GOT TO MOVE IT MOVE IT


### PR DESCRIPTION
Full disclosure: this commit and the following description was authored by Claude after I described the problem I was seeing. I have no experience developing Chrome extensions but it did seem to fix the issue.

Fixes inconsistent tab placement on Chrome — both the steady-state case (new tabs sometimes landing in their default position instead of right of the active tab) and a session-restore regression (tabs occasionally getting reordered or absorbed into adjacent groups on browser reopen).

The root cause is the MV3 service-worker lifecycle interacting badly with Chrome's session-restore behavior. Most of the patch is plumbing to handle that correctly; a few smaller staleness/correctness issues are fixed alongside.

Adds the `"storage"` permission to `manifest.json` (needed for `chrome.storage.session`; no install warning).

## Bugs fixed

### 1. `activeTabCache` is lost when the service worker terminates

`activeTabCache` was only populated from `tabs.onActivated`, which fires on user tab switches — it does **not** refire when the SW wakes back up from idle. So new tabs opened after any SW termination (idle timeout, browser restart, extension update, crash) silently fell through to Chrome's default placement. The existing `keepAlive` heartbeat helps but doesn't cover all the termination cases.

**Fix:** rehydrate the cache via `tabs.query({active: true, windowId})` when it's empty, plus a separate "user has activated a tab in this session" gate (see below) that survives SW restarts.

### 2. `tabs.onActivated` can't be the sole "user has interacted" signal

Chrome auto-activates the active restored tab during session restore, firing `onActivated` before the rest of the restored tabs finish their `onCreated` events. That made naive use of the cache scramble restored tab order and rip tabs out of their groups.

**Fix:** activation decisions are now debounced by `QUIESCENCE_MS` (50ms). When the event stream goes quiet, we count the recent `onCreated` events — a burst means session restore (don't open the gate), a single event means a real user click (open the gate). The result is persisted in `chrome.storage.session` so it survives SW restarts within a browser session, and is cleared on `runtime.onStartup` and on the last window being removed (the case where Chrome's background process keeps the session alive but the user has effectively ended their session).

### 3. Tab groups can be broken even when the gate is correct

During session restore, grouped tabs come in with `groupId === -1` at `onCreated` and get their actual group ID assigned via a follow-up `onUpdated` event milliseconds later. Without a re-check, the extension can yank tabs out of groups that Chrome was about to assign them to. There's also an inverse failure mode where a tab gets *moved into* a group it was never part of (when its target index lands inside an existing group's range — Chrome auto-merges).

**Fix:** check `groupId` once at the event payload (catches tabs Chrome already placed in a group, e.g. Ctrl+T inside a group) and again right before the move on a fresh refetch (catches tabs whose group was assigned by `onUpdated` between `onCreated` and our move).

### 4. Stale references across awaits

Both `activeTabCache` and the `newTab` event payload go stale across awaits — the active tab can move/close, and the new tab's index changes as Chrome continues to process other restored tabs. Refetching both right before the move (in parallel via `Promise.all`) avoids the resulting off-by-one misplacements.

### 5. `windows.getCurrent()` returns the focused window

Not necessarily the one the new tab was created in. Replaced with `windows.get(newTab.windowId, {populate: true})`, folded into the `Promise.all` alongside the tab refetches since we always need the populated tab list now (see #6).

### 6. The "rightmost-only" filter had a staleness bug, not a logic bug

The original filter:

```js
if (newTab.index < win.tabs.length - 1 || newTab.index > win.tabs.length - 1) {
  return;
}
```

…compared a stale `newTab.index` (from the event payload, captured at the moment Chrome dispatched `onCreated`) against a freshly-queried `win.tabs.length`. The values can drift apart by the time the `await windows.getCurrent` resolves, producing wrong skip decisions.

I initially read the filter as "only move if the new tab is currently the rightmost" and removed it as broken — but the *intent* was load-bearing: a fresh user-initiated tab (Ctrl+T, click "+") always lands at the end of the strip; anything else (Ctrl+Shift+T restoring to original position, single-tab session restore, middle-click placed adjacent to a non-active opener) represents Chrome placing the tab somewhere intentional that the extension shouldn't override. The original author's comment ("Maybe is a restored tab, or another add-on, or something else is wonky.") spells out exactly what they were guarding against.

**Fix:** keep the filter, but use the freshly-fetched `freshNewTab.index` so it compares like-for-like against `win.tabs.length`. Both values come from the same `Promise.all` batch.

### 7. Duplicate keepAlive interval on cold start

`keepAlive()` was called at top-level *and* registered as a `runtime.onStartup` listener, so each cold start leaked a second 20s heartbeat. Top-level alone runs on every SW boot, so the listener is redundant.

## Implementation notes

- The burst-detect / debounce logic uses one constant (`QUIESCENCE_MS = 50`). It represents the *inter-event gap* needed to call the event stream "quiet," not the total burst duration — so it doesn't make assumptions about how long a session restore takes overall. A 200-tab restore works the same way as a 6-tab restore: each `onCreated` extends the timer, and the decision only fires once the burst has fully ended.
- There's no Chrome API for "session restore is in progress" (the chromium bug already linked in the file is exactly this gap), so the burst-detection is heuristic. It's the most principled version I could come up with given the API surface.